### PR TITLE
SCDA: Fix invalid soundtrack URL

### DIFF
--- a/wfp.html
+++ b/wfp.html
@@ -2555,7 +2555,7 @@
                     <i class="icon-scgoggles scgoggles-color d-flex justify-content-center align-items-center"></i>
                   </a>
                   <a class="btn btn-social-icon btn-social-light float-end ms-1 mb-1" target="_blank"
-                    href="http://www.behaviormusic.com/projects/splinter-cell-double-agent-soundtrack/"
+                    href="https://michaelmccann.io/projects/splinter-cell-double-agent-soundtrack/"
                     data-bs-placement="left" data-bs-toggle="tooltip"
                     data-bs-original-title="Splinter Cell: Double Agent – Soundtrack">
                     <i class=" icon-file-music1 d-flex justify-content-center align-items-center"></i>


### PR DESCRIPTION
The old URL no longer belongs to Michael McCann and was leading to a random site. Updated the URL to point to his new official site.